### PR TITLE
Add persistent sessions and reworked UI

### DIFF
--- a/client/src/components/ConnectToServerForm.tsx
+++ b/client/src/components/ConnectToServerForm.tsx
@@ -1,61 +1,60 @@
 import React, { useState } from 'react';
-import { Form, Button } from 'react-bootstrap';
+import { Button, Form } from 'react-bootstrap';
 import { validateUsername } from 'common/lib/details';
 
-interface SelectUsernameProps {
+interface ConnectToServerProps {
   onValidated: (username: string) => void;
-  label?: string;
   disabled?: boolean;
 }
 
-const SelectUsername: React.FC<SelectUsernameProps> = ({
+const ConnectToServerForm: React.FC<ConnectToServerProps> = ({
   onValidated,
-  label,
   disabled,
 }) => {
   const [username, setUsername] = useState('');
-  const [error, setError] = useState('');
-  const [validated, setValidated] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [label, setLabel] = useState(<>Connect</>);
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
     event.stopPropagation();
 
     let status = validateUsername(username);
-
     if (!username || username === '') {
-      setError('Please Choose a Username');
+      setError('Please choose a Username');
     } else if (status !== true) {
       setError(status);
     } else {
-      setError('');
-      setValidated(status);
+      setError(null);
       onValidated(username);
+      setLabel(<>Connecting...</>);
     }
   };
 
   return (
-    <Form inline validated={validated} onSubmit={handleSubmit}>
+    <Form inline onSubmit={handleSubmit}>
       <Form.Group>
         <Form.Label htmlFor='username' srOnly>
           Username
         </Form.Label>
         <Form.Control
+          required
           as='input'
           type='text'
           className='mr-4 mt-4'
           id='username'
           placeholder='Choose a Username...'
-          isInvalid={error !== ''}
+          isInvalid={error != null}
           onChange={(e) => setUsername(e.target.value)}
+          disabled={disabled}
         />
         <Button
           type='submit'
           className='mt-4'
           variant='primary'
-          disabled={disabled || validated}
+          disabled={disabled}
         >
-          {label ? label : 'Submit'}
+          {label}
         </Button>
         <Form.Control.Feedback type='invalid'>{error}</Form.Control.Feedback>
       </Form.Group>
@@ -63,4 +62,4 @@ const SelectUsername: React.FC<SelectUsernameProps> = ({
   );
 };
 
-export default SelectUsername;
+export default ConnectToServerForm;

--- a/client/src/components/FindGameButton.tsx
+++ b/client/src/components/FindGameButton.tsx
@@ -1,0 +1,65 @@
+import { Spinner, Button } from 'react-bootstrap';
+
+export type FindGameState = 'initial' | 'searching' | 'found' | 'error';
+export interface FindGameProps {
+  state: FindGameState;
+  disabled: boolean;
+  onClick: () => void;
+}
+
+const FindGameButton: React.FC<FindGameProps> = ({
+  state,
+  disabled,
+  onClick,
+}) => {
+  // TODO add a way for user to cancel search after they clicked find game
+
+  let label = <>Find Game</>;
+  let variant = 'outline-primary';
+
+  if (!disabled) {
+    switch (state) {
+      case 'searching':
+        disabled = true;
+        label = (
+          <>
+            <Spinner
+              as='span'
+              animation='grow'
+              size='sm'
+              role='status'
+              aria-hidden='true'
+              className='mr-2 mb-1'
+            />
+            Finding Game...
+          </>
+        );
+        break;
+      case 'found':
+        disabled = true;
+        variant = 'primary';
+        label = <>Game Found!</>;
+        break;
+      case 'error':
+        variant = 'outline-danger';
+        label = <>An error occured 😞</>;
+        break;
+      case 'initial':
+      default:
+        break;
+    }
+  }
+  return (
+    <Button
+      variant={variant}
+      size='lg'
+      className='mr-4 mt-3'
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {label}
+    </Button>
+  );
+};
+
+export default FindGameButton;

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -13,7 +13,7 @@ export default function Footer() {
       variant='dark'
       as='footer'
       className='mt-3'
-      fixed={dimensions.width >= 768 ? 'bottom' : undefined}
+      fixed={dimensions.height >= 955 ? 'bottom' : undefined}
     >
       <Container className='align-items-center justify-content-center'>
         <p className='theme-text-secondary text-center'>Some text and stuff</p>

--- a/client/src/components/JoinGameButton.tsx
+++ b/client/src/components/JoinGameButton.tsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import { Button, Spinner, Collapse, Form } from 'react-bootstrap';
+
+interface JoinGameProps {
+  onSubmit: (roomCode: string) => true | string;
+  disabled: boolean;
+}
+
+const JoinGameButton: React.FC<JoinGameProps> = ({ onSubmit, disabled }) => {
+  const [open, setOpen] = useState(false);
+  const [label, setLabel] = useState(<>Join Game</>);
+
+  const [roomCode, setRoomCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    let status = onSubmit(roomCode); // TODO attempt to connect to room
+    if (!roomCode || roomCode === '') {
+      setError('Please enter a room ID');
+    } else if (status !== true) {
+      setError(status);
+    } else {
+      setError(null);
+      setLabel(
+        <>
+          <Spinner
+            as='span'
+            animation='grow'
+            size='sm'
+            role='status'
+            aria-hidden='true'
+            className='mr-2 mb-1'
+          />
+          Joining Game!
+        </>
+      );
+      setOpen(false);
+    }
+  };
+
+  const handleClick = () => {
+    setOpen(!open);
+    if (!open) {
+      setLabel(<>Close</>);
+    } else {
+      setLabel(<>Join Game</>);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        variant='outline-success'
+        size='lg'
+        className='mr-4 mt-3'
+        onClick={handleClick}
+        disabled={disabled}
+        aria-controls='join-game-prompt'
+        aria-expanded={open}
+      >
+        {label}
+      </Button>
+      <div className='d-inline'>
+        <Collapse in={open}>
+          <Form inline onSubmit={handleSubmit} id='join-game-form'>
+            <Form.Group>
+              <Form.Label htmlFor='roomCode' srOnly>
+                Room Code
+              </Form.Label>
+              <Form.Control
+                required
+                as='input'
+                type='text'
+                className='mr-4 mt-4'
+                id='username'
+                placeholder='Enter Room Code...'
+                isInvalid={error != null}
+                onChange={(e) => setRoomCode(e.target.value)}
+                disabled={disabled}
+              />
+              <Button
+                type='submit'
+                className='mt-4'
+                variant='primary'
+                disabled={disabled}
+              >
+                Join!
+              </Button>
+              <Form.Control.Feedback type='invalid'>
+                {error}
+              </Form.Control.Feedback>
+            </Form.Group>
+          </Form>
+        </Collapse>
+      </div>
+    </>
+  );
+};
+
+export default JoinGameButton;

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -5,5 +5,7 @@ export { default as Navigation } from './Navbar';
 export { default as Footer } from './Footer';
 export { default as ServerStats } from './ServerStats';
 export { default as Leaderboard } from './Leaderboard';
-export { default as SelectUsername } from './SelectUsername';
+export { default as ConnectToServerForm } from './ConnectToServerForm';
+export { default as FindGameButton } from './FindGameButton';
+export { default as JoinGameButton } from './JoinGameButton';
 export { default as MatchMakingGroup } from './MatchMakingGroup';

--- a/client/src/contexts/Socket.ts
+++ b/client/src/contexts/Socket.ts
@@ -2,21 +2,49 @@ import React from 'react';
 import { io, Socket } from 'socket.io-client';
 import { Server, Client, Common } from 'common/lib/events';
 
-const SERVER_PORT = process.env.REACT_APP_SERVER_PORT || 8080;
+export interface ClientSocket extends Socket<Server.Events, Client.Events> {
+  username?: string;
+  userID?: string;
+  sessionID?: string;
+}
+
+export const SERVER_PORT = process.env.REACT_APP_SERVER_PORT || 8080;
 export const SERVER_URL =
   process.env.REACT_APP_SERVER_URI || `http://localhost:${SERVER_PORT}`;
 
-export const socket: Socket<Server.Events, Client.Events> = io(SERVER_URL, {
+export const socket: ClientSocket = io(SERVER_URL, {
   autoConnect: false,
 });
 export const SocketContext = React.createContext(socket);
+
+export const hasSessionID = () => {
+  return localStorage.getItem('sessionID') !== null;
+};
 
 socket.on(Server.Connect, () => {
   console.log(`Connected to server at ${SERVER_URL}`);
 });
 
+socket.on(Server.CreateSession, ({ username, userID, sessionID }) => {
+  localStorage.setItem('sessionID', sessionID);
+  socket.userID = userID;
+  socket.username = username;
+
+  if (socket.sessionID && sessionID !== socket.sessionID) {
+    console.warn('sessionID mismatch');
+  }
+  socket.sessionID = sessionID;
+
+  console.log(`Created session: ${username}:${userID}:${sessionID}`);
+});
+
 socket.on(Server.ConnectError, (err: Error) => {
-  console.log(`Failure to connect to ${SERVER_URL}: ${err}`);
+  console.log(`Failure to connect to ${SERVER_URL}: ${err.message}`);
+  if (err.message === 'session not found') {
+    socket.auth = {};
+    socket.sessionID = undefined;
+    localStorage.removeItem('sessionID');
+  }
 });
 
 socket.on(Server.Disconnect, (reason: string) => {
@@ -26,3 +54,15 @@ socket.on(Server.Disconnect, (reason: string) => {
 socket.on(Common.DebugMessage, (msg: string) => {
   console.log(msg);
 });
+
+const initSocket = () => {
+  let sessionID = localStorage.getItem('sessionID');
+  if (sessionID) {
+    // Resume session if it exists
+    socket.sessionID = sessionID;
+    socket.auth = { sessionID };
+    socket.connect();
+  }
+};
+
+initSocket();

--- a/common/events.ts
+++ b/common/events.ts
@@ -46,12 +46,27 @@ export namespace Server {
   export const Disconnect = 'disconnect';
 
   /**
+   * Event fires after user connects, provides client with session details
+   */
+  export const CreateSession = 'create_session';
+
+  /**
+   * Session details
+   */
+  export interface Session {
+    username: string;
+    userID: string;
+    sessionID: string;
+  }
+
+  /**
    * Typed events interface for Server to Client
    */
   export interface Events extends Common.Events {
     connect_error: (err: Error) => void;
     connect: () => void;
     disconnect: () => void;
+    create_session: (session: Session) => void;
   }
 }
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,0 +1,18 @@
+/**
+ * Battleship server configuration file
+ */
+import cors from 'cors';
+
+export const CLIENT_PORT = process.env.PORT || 3000;
+
+export const PORT = process.env.SERVER_PORT || 8080;
+
+export const SECRET = process.env.SECRET || 'development-key';
+
+export const ALLOWED_ORIGINS =
+  process.env.ALLOWED_ORIGINS || `http://localhost:${CLIENT_PORT}`;
+
+export const CORS_OPTIONS: cors.CorsOptions = {
+  origin: ALLOWED_ORIGINS.split(',').map((s) => new RegExp(s)),
+  methods: ['GET', 'POST'],
+};

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -9,53 +9,87 @@ import { Server as IO, Socket } from 'socket.io';
 import cors from 'cors';
 import { validateUsername } from 'common/lib/details';
 import { Server, Client, Common } from 'common/lib/events';
-
-interface ClientSocket extends Socket<Client.Events, Server.Events> {
-  username: string;
-}
-
-// Server configuration
-const client_port = process.env.PORT || 3000;
-const port = process.env.SERVER_PORT || 8080;
-const allowedOrigins =
-  process.env.ALLOWED_ORIGINS || `http://localhost:${client_port}`;
-const corsOptions: cors.CorsOptions = {
-  origin: allowedOrigins.split(',').map((s) => new RegExp(s)),
-  methods: ['GET', 'POST'],
-};
+import { ExtendedSocket } from './utils';
+import { genID } from './session';
+import * as config from './config';
+import { MemorySessionStore } from './session';
 
 /// Setup server and socket.io
 const app = Express();
 const server = createServer(app);
 const io = new IO<Client.Events, Server.Events>(server, {
   // https://socket.io/docs/v4/server-initialization/#Options
-  cors: corsOptions,
+  cors: config.CORS_OPTIONS,
 });
+const sessionStore = new MemorySessionStore();
 
 /// Setup Middleware
-app.use(cors(corsOptions));
+app.use(cors(config.CORS_OPTIONS));
 
-io.use((socket: ClientSocket, next) => {
-  const username = socket.handshake.auth.username;
-  let status = validateUsername(username);
-  if (status === true) {
-    socket.username = username;
-    next();
+// TODO: refactor, lots of if/elses
+io.use((socket: ExtendedSocket, next) => {
+  const sessionID = socket.handshake.auth.sessionID;
+  if (sessionID) {
+    // Resume session if it exists
+    let session = sessionStore.get(sessionID);
+    if (session) {
+      socket.username = session.username;
+      socket.userID = session.userID;
+      socket.sessionID = sessionID;
+      return next();
+    } else {
+      // TODO make server errors named constants in the common library
+      return next(new Error('session not found'));
+    }
   } else {
-    return next(new Error(status));
+    // Create new session
+    const username = socket.handshake.auth.username;
+    let status = validateUsername(username);
+    if (status === true) {
+      socket.username = username;
+      socket.userID = genID();
+      socket.sessionID = genID();
+      next();
+    } else {
+      return next(new Error(status));
+    }
   }
 });
 
 /// Socket IO event handlers
-io.on(Client.Connection, (socket: ClientSocket) => {
-  console.log(`connection[${socket.username}:${socket.id}] : user connected`);
+io.on(Client.Connection, (socket: ExtendedSocket) => {
+  console.log(
+    `connection[${socket.username}:${socket.sessionID}] : user connected`
+  );
+
+  // Persist session
+  sessionStore.set(socket.sessionID, {
+    username: socket.username,
+    userID: socket.userID,
+    connected: true,
+  });
+
+  // Update session details on the client
+  socket.emit(Server.CreateSession, {
+    username: socket.username,
+    userID: socket.userID,
+    sessionID: socket.sessionID,
+  });
 
   socket.on(Common.DebugMessage, (msg: string) => {
-    console.log(`debug[${socket.username}:${socket.id}]: ${msg}`);
+    console.log(`debug[${socket.username}:${socket.sessionID}]: ${msg}`);
   });
 
   socket.on(Client.Disconnect, (reason: string) => {
-    console.log(`disconnect[${socket.username}:${socket.id}] : ${reason}`);
+    console.log(
+      `disconnect[${socket.username}:${socket.sessionID}] : ${reason}`
+    );
+
+    sessionStore.set(socket.sessionID, {
+      username: socket.username,
+      userID: socket.userID,
+      connected: false,
+    });
   });
 });
 
@@ -64,7 +98,6 @@ app.get('/', (req, res) => {
   res.status(200).json({
     status: 'running',
     activeClients: io.sockets.sockets.size,
-    allowedOrigins: allowedOrigins, // TODO this is here as a sanity check, should remove in future versions
   });
 });
 
@@ -89,6 +122,6 @@ app.get('/stats', (req, res) => {
 });
 
 /// Start the server!
-server.listen(port, () => {
-  console.log(`Listening on port ${port}...`);
+server.listen(config.PORT, () => {
+  console.log(`Listening on port ${config.PORT}...`);
 });

--- a/server/src/session.ts
+++ b/server/src/session.ts
@@ -1,0 +1,76 @@
+import crypto from 'crypto';
+
+export const genID = () => crypto.randomBytes(10).toString('hex');
+
+export type SessionID = string;
+export type UserID = string;
+
+export type Session = {
+  username: string;
+  userID: UserID;
+  connected: boolean;
+  expiry?: number;
+};
+
+interface SessionStore {
+  get: (sid: SessionID) => Session | undefined;
+  set: (sid: SessionID, session: Session) => boolean;
+  all: () => Session[];
+  destroy: (sid: SessionID) => boolean;
+  clear: () => void;
+  touch: (sid: SessionID) => boolean;
+}
+
+export type MemorySessionOptions = {
+  ttl: number;
+};
+
+export class MemorySessionStore implements SessionStore {
+  store: Map<SessionID, Session>;
+  opts: MemorySessionOptions;
+
+  constructor(opts?) {
+    this.store = new Map<SessionID, Session>();
+    this.opts = opts || { ttl: 86400 };
+  }
+
+  get(sid: SessionID) {
+    let session = this.store.get(sid);
+    if (session) {
+      if (Date.now() > session.expiry) {
+        this.destroy(sid);
+      } else {
+        return session;
+      }
+    }
+    return undefined;
+  }
+
+  set(sid: SessionID, session: Session) {
+    let expiry = Date.now() + this.opts.ttl;
+    this.store.set(sid, { ...session, expiry });
+    return true;
+  }
+
+  all() {
+    return [...this.store.values()];
+  }
+
+  destroy(sid: SessionID) {
+    return this.store.delete(sid);
+  }
+
+  clear() {
+    this.store.clear();
+  }
+
+  touch(sid: SessionID) {
+    let session = this.get(sid);
+    if (session) {
+      session.expiry = Date.now() + this.opts.ttl;
+      return true;
+    } else {
+      return false;
+    }
+  }
+}

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -1,0 +1,16 @@
+/**
+ *  Battleship server utility functions and types
+ */
+
+import { Socket } from 'socket.io';
+import { Server, Client } from 'common/lib/events';
+import { SessionID, Session } from './session';
+
+// Socket.IO middleware wrapper
+export const wrap = (middleware) => (socket, next) =>
+  middleware(socket.request, {}, next);
+
+export type ExtendedSocket = Socket<Client.Events, Server.Events> &
+  Session & {
+    sessionID: SessionID;
+  };


### PR DESCRIPTION
PR addresses #29  and adds persistent User and Session ID's for the client. Now when a client refreshes the page or opens a new browser tab they will resume the current session with the server. 

Current implementation for the session store is an in memory session store which get erased whenever the server resets. This obviously won't scale well and we will need to eventually create a centralized store somewhere eventually. 