### PR TITLE
Session Error locks up UI Fix

### DIFF
--- a/client/src/components/MatchMakingGroup.tsx
+++ b/client/src/components/MatchMakingGroup.tsx
@@ -82,7 +82,14 @@ const MatchMakingGroup = () => {
     setDisableButtons(false);
   }, []);
 
-  const handleConnectError = useCallback(() => {
+  const handleConnectError = useCallback((err: Error) => {
+    setConnected(false);
+    if (err.message !== 'session not found') {
+      setConnectError(true);
+    }
+  }, []);
+
+  const handleDisconnect = useCallback((reason: String) => {
     setConnected(false);
     setConnectError(true);
   }, []);
@@ -90,13 +97,13 @@ const MatchMakingGroup = () => {
   useEffect(() => {
     socket.on(Server.Connect, handleConnect);
     socket.on(Server.ConnectError, handleConnectError);
-    socket.on(Server.Disconnect, handleConnectError);
+    socket.on(Server.Disconnect, handleDisconnect);
     return () => {
       socket.off(Server.Connect, handleConnect);
       socket.off(Server.ConnectError, handleConnectError);
       socket.off(Server.Disconnect, handleConnectError);
     };
-  });
+  }, [socket, handleConnect, handleConnectError, handleDisconnect]);
 
   const nodeRef = React.createRef<HTMLDivElement>();
 
@@ -110,7 +117,7 @@ const MatchMakingGroup = () => {
           nodeRef={nodeRef}
         >
           <div ref={nodeRef}>
-            {connected || hasSessionID() ? (
+            {connected ? (
               <div>
                 <FindGameButton
                   disabled={connectError || disableButtons}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -185,7 +185,7 @@ app.get('/stats', (req, res) => {
   res.status(200).json({
     playersOnline: io.sockets.sockets.size,
     activeGames: gameStore.length(),
-    gamesPlayed: gameStore.length(), // TODO return actual value
+    gamesPlayed: gameStore.length(), // TODO track number of games played and return that value
   });
 });
 


### PR DESCRIPTION
Fixed #33 , Instead of locking up the UI whenever there is a connect error we instead check if it's because we need to reauthenticate a session first. PR also fixes a critical null reference bug that was crashing the server