### PR TITLE
Forfeit and GameID UI elements, Switch to session storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ See the `package.json` file for a full list of commands but the primary commands
 |
 ├───common              <-- Server/Client shared code e.g. Game logic, event types
 │   └───lib
-├───docs                <-- Documentatoin
+├───docs                <-- Documentation
 |
 └───server              <-- Battleship express server
     └───src

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,7 +15,6 @@ function App() {
             <Route path='/' exact component={Home} />
             <Route path='*' component={NotFound} />
           </Switch>
-          <Footer />
         </Router>
       </SocketContext.Provider>
     </main>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import { socket, SocketContext } from './contexts';
-import { Navigation, Footer } from './components';
+import { Navigation } from './components';
 import { Home, About, Game, NotFound } from './pages';
 
 function App() {

--- a/client/src/components/ChatWindow.tsx
+++ b/client/src/components/ChatWindow.tsx
@@ -37,7 +37,16 @@ const ChatWindow = () => {
   const socket = useContext(SocketContext);
   const [disabled, setDisabled] = useState(false);
   const [message, setMessage] = useState('');
-  const [messages, setMessages] = useState<Message[]>([]);
+  const [messages, setMessages] = useState<Message[]>([
+    {
+      username: ServerName,
+      msg: `Game ID - ${roomID}`,
+    },
+    {
+      username: ServerName,
+      msg: 'Type "forfeit" to resign from game',
+    },
+  ]);
 
   const messageEndRef = useRef<HTMLDivElement>(null);
 
@@ -49,7 +58,11 @@ const ChatWindow = () => {
     event.preventDefault();
     event.stopPropagation();
 
-    socket.emit(Client.ChatMessage, roomID, message);
+    if (message.toLowerCase() === 'forfeit') {
+      socket.emit(Client.Resign, roomID);
+    } else {
+      socket.emit(Client.ChatMessage, roomID, message);
+    }
 
     setMessage('');
   };

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -1,8 +1,8 @@
 import { Container, Navbar } from 'react-bootstrap';
-//import { useWindowDimensions } from '../hooks';
+import { useWindowDimensions } from '../hooks';
 
 export default function Footer() {
-  //const dimensions = useWindowDimensions();
+  const dimensions = useWindowDimensions();
 
   // TODO magic number, attempting to make the navbar non-fixed on smaller
   // screens here. This is what I came up with but it's mostly a hack.
@@ -13,8 +13,7 @@ export default function Footer() {
       variant='dark'
       as='footer'
       className='mt-3'
-      // TODO get this footer to be fixed on short pages
-      //fixed={dimensions.height >= 955 ? 'bottom' : undefined}
+      fixed={dimensions.height >= 955 ? 'bottom' : undefined}
     >
       <Container className='align-items-center justify-content-center'>
         <p className='theme-text-secondary text-center'>Some text and stuff</p>

--- a/client/src/contexts/Socket.ts
+++ b/client/src/contexts/Socket.ts
@@ -26,7 +26,7 @@ socket.on(Server.Connect, () => {
 });
 
 socket.on(Server.CreateSession, ({ username, userID, sessionID }) => {
-  localStorage.setItem('sessionID', sessionID);
+  sessionStorage.setItem('sessionID', sessionID);
   socket.userID = userID;
   socket.username = username;
 
@@ -43,7 +43,7 @@ socket.on(Server.ConnectError, (err: Error) => {
   if (err.message === 'session not found') {
     socket.auth = {};
     socket.sessionID = undefined;
-    localStorage.removeItem('sessionID');
+    sessionStorage.removeItem('sessionID');
   }
 });
 
@@ -56,7 +56,7 @@ socket.on(Common.DebugMessage, (msg: string) => {
 });
 
 const initSocket = () => {
-  let sessionID = localStorage.getItem('sessionID');
+  let sessionID = sessionStorage.getItem('sessionID');
   if (sessionID) {
     // Resume session if it exists
     socket.sessionID = sessionID;

--- a/client/src/pages/About.tsx
+++ b/client/src/pages/About.tsx
@@ -1,3 +1,5 @@
+import { Footer } from '../components';
+
 export default function About() {
   return (
     <div className='about'>
@@ -8,6 +10,7 @@ export default function About() {
         impedit, saepe dolore nam ex sapiente architecto, perferendis natus
         voluptatem consequatur?
       </p>
+      <Footer />
     </div>
   );
 }

--- a/client/src/pages/Game.tsx
+++ b/client/src/pages/Game.tsx
@@ -119,7 +119,6 @@ const Game = () => {
           return HoverStyle.Action;
         }
       }
-      console.log(playerState?.ships);
       return HoverStyle.None;
     },
     [playerState]
@@ -180,7 +179,6 @@ const Game = () => {
     }
     return () => {
       socket.off(Server.UpdateGameState, handleGameUpdate);
-      socket.emit(Client.LeaveRoom, gameID || 'unknown');
     };
   }, [socket, gameID, handleGameUpdate, playerState]);
 

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -5,7 +5,12 @@ import {
   Container,
   ListGroup,
 } from 'react-bootstrap';
-import { ServerStats, Leaderboard, MatchMakingGroup } from '../components';
+import {
+  ServerStats,
+  Leaderboard,
+  MatchMakingGroup,
+  Footer,
+} from '../components';
 
 export default function Home() {
   return (
@@ -18,9 +23,6 @@ export default function Home() {
             browser
           </p>
           <hr className='mb-4' />
-          <blockquote className='blockquote'>
-            <p className='lead mb-0'>random naval battlefact</p>
-          </blockquote>
           <MatchMakingGroup />
         </Container>
       </Jumbotron>
@@ -64,6 +66,7 @@ export default function Home() {
           </Card>
         </CardDeck>
       </Container>
+      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
PR Closes #44 , Closes #45 , Closes #47  and Closes #33 . Instead of adding a forfeit button, I opted to allow the user to type "forfeit" into the chat window, which will trigger the forfeit event. The chat window also displays the game ID of the room when a user connects. Also very hastily added server chat feedback for when a new user enters a room. Lastly, switched the session tokens to be stored in `sessionStorage` instead of `localStorage`. 